### PR TITLE
Support Foreman hosts that are unmanaged

### DIFF
--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -61,6 +61,8 @@ type ForemanHost struct {
 	BMCSuccess bool
 	// Additional information about this host
 	Comment string `json:"comment"`
+	// Boolean for whether Foreman manages this host
+	Managed bool `json:"managed"`
 	// Nested struct defining any interfaces associated with the Host
 	InterfacesAttributes []ForemanInterfacesAttribute `json:"interfaces_attributes"`
 }
@@ -125,6 +127,7 @@ func (fh ForemanHost) MarshalJSON() ([]byte, error) {
 
 	fhMap["name"] = fh.Name
 	fhMap["comment"] = fh.Comment
+	fhMap["managed"] = fh.Managed
 	fhMap["build"] = fh.Build
 	fhMap["domain_id"] = intIdToJSONString(fh.DomainId)
 	fhMap["operatingsystem_id"] = intIdToJSONString(fh.OperatingSystemId)
@@ -133,9 +136,12 @@ func (fh ForemanHost) MarshalJSON() ([]byte, error) {
 	if len(fh.InterfacesAttributes) > 0 {
 		fhMap["interfaces_attributes"] = fh.InterfacesAttributes
 	}
-	log.Debugf("fhMap: [%+v]", fhMap)
+	hostMap := map[string]interface{}{
+		"host": fhMap,
+	}
+	log.Debugf("hostMap: [%+v]", fhMap)
 
-	return json.Marshal(fhMap)
+	return json.Marshal(hostMap)
 }
 
 // Custom JSON unmarshal function. Unmarshal to the unexported JSON struct
@@ -175,6 +181,9 @@ func (fh *ForemanHost) UnmarshalJSON(b []byte) error {
 	}
 	if fh.Comment, ok = fhMap["comment"].(string); !ok {
 		fh.Comment = ""
+	}
+	if fh.Managed, ok = fhMap["managed"].(bool); !ok {
+		fh.Managed = true
 	}
 	if _, ok = fhMap["domain_id"].(float64); !ok {
 		fh.DomainId = 0

--- a/foreman/resource_foreman_host_test.go
+++ b/foreman/resource_foreman_host_test.go
@@ -83,13 +83,14 @@ func RandForemanHost() api.ForemanHost {
 	obj.ForemanObject = fo
 
 	obj.Build = rand.Intn(2) > 0
+	obj.Managed = rand.Intn(2) > 0
 	obj.OperatingSystemId = rand.Intn(100)
 	obj.DomainId = rand.Intn(100)
 	obj.HostgroupId = rand.Intn(100)
 	obj.EnvironmentId = rand.Intn(100)
 
 	obj.InterfacesAttributes = make([]api.ForemanInterfacesAttribute, rand.Intn(5))
-	for idx, _ := range obj.InterfacesAttributes {
+	for idx := range obj.InterfacesAttributes {
 		obj.InterfacesAttributes[idx] = api.ForemanInterfacesAttribute{
 			Id:         rand.Intn(100),
 			SubnetId:   rand.Intn(100),
@@ -316,7 +317,12 @@ func ResourceForemanHostRequestDataTestCases(t *testing.T) []TestCaseRequestData
 	obj = *buildForemanHost(rd)
 	// NOTE(ALL): See note in Create and Update functions for build flag
 	//   override
-	obj.Build = true
+	if obj.Managed {
+		obj.Build = true
+	} else {
+		obj.Build = false
+	}
+
 	reqData, _ := json.Marshal(obj)
 
 	return []TestCaseRequestData{


### PR DESCRIPTION
This adds support for unmanaged hosts in Foreman. I also encountered what appeared to be a bug where the data sent to Foreman was repeated at the top-level as well as in the`host` key.

Foreman (v1.17) was receiving:
```
{"build"=>false, "comment"=>"", "domain_id"=>nil, "environment_id"=>"1", "hostgroup_id"=>"1", "managed"=>false, "name"=>"host.example.org", "operatingsystem_id"=>nil, "apiv"=>"v2", "host"=>{"build"=>false, "comment"=>"", "managed"=>false, "name"=>"host.example.org", "domain_id"=>nil, "environment_id"=>"1", "hostgroup_id"=>"1", "operatingsystem_id"=>nil}}
```
whereas it should only get
```
{"host"=>{"build"=>false, "comment"=>"", "managed"=>false, "name"=>"host.example.org", "domain_id"=>nil, "environment_id"=>"1", "hostgroup_id"=>"1", "operatingsystem_id"=>nil}}
```
and the extra data was causing it to throw a `Hostgroup not found by id` error.